### PR TITLE
Add monthly budget management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ This example shows how to use Flask 3 on Vercel with Serverless Functions using 
 
 https://flask-python-template.vercel.app/
 
+## Monthly Budget Page
+
+This project now includes a simple page to manage a monthly budget. Visit
+`/api/budget` when running locally to set a spending limit and record
+expenses. The page shows the total spent and the remaining budget for the
+month.
+
 ## How it Works
 
 This example uses the Web Server Gateway Interface (WSGI) with Flask to enable handling requests on Vercel with Serverless Functions.

--- a/api/index.py
+++ b/api/index.py
@@ -1,11 +1,66 @@
-from flask import Flask
+from flask import Flask, request, render_template_string
 
 app = Flask(__name__)
 
-@app.route('/')
-def home():
-    return 'Hello, World!'
 
-@app.route('/about')
+@app.route("/")
+def home():
+    return "Hello, World!"
+
+
+@app.route("/about")
 def about():
-    return 'About'
+    return "About"
+
+
+budget_data = {"limit": 0.0, "expenses": []}
+
+
+@app.route("/budget", methods=["GET", "POST"])
+def budget():
+    """Simple in-memory monthly budget tracker."""
+    if request.method == "POST":
+        if "limit" in request.form:
+            try:
+                budget_data["limit"] = float(request.form["limit"])
+            except ValueError:
+                pass
+        elif "name" in request.form and "amount" in request.form:
+            try:
+                amount = float(request.form["amount"])
+                budget_data["expenses"].append(
+                    {"name": request.form["name"], "amount": amount}
+                )
+            except ValueError:
+                pass
+    total_spent = sum(e["amount"] for e in budget_data["expenses"])
+    remaining = budget_data["limit"] - total_spent
+    return render_template_string(
+        """
+        <!doctype html>
+        <title>Monthly Budget</title>
+        <h1>Monthly Budget</h1>
+        <form method="post">
+            <label>Set monthly budget: <input name="limit" type="number" step="0.01" value="{{ limit }}"></label>
+            <button type="submit">Save</button>
+        </form>
+        <h2>Add Expense</h2>
+        <form method="post">
+            <input name="name" placeholder="Expense name">
+            <input name="amount" type="number" step="0.01" placeholder="Amount">
+            <button type="submit">Add</button>
+        </form>
+        <h2>Summary</h2>
+        <ul>
+            {% for e in expenses %}
+            <li>{{ e.name }}: {{ e.amount }}</li>
+            {% endfor %}
+        </ul>
+        <p>Total spent: {{ total_spent }}</p>
+        <p>Remaining: {{ remaining }}</p>
+        """,
+        limit=budget_data["limit"],
+        expenses=budget_data["expenses"],
+        total_spent=total_spent,
+        remaining=remaining,
+    )


### PR DESCRIPTION
## Summary
- add /budget route with an in-memory monthly budget tracker
- document budget feature in README

## Testing
- `python -m py_compile api/index.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3c57a032c832d944ed52935fb456a